### PR TITLE
ApplicationAssignmentDto's Role property changed to RoleId

### DIFF
--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationAssignmentDto.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationAssignmentDto.cs
@@ -8,6 +8,6 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
         public Guid? ApplicationId { get; set; }
         public Guid? UserId { get; set; }
         public string User { get; set; }
-        public string Role { get; set; }
+        public Guid? RoleId { get; set; }
     }
 }

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationRoleAssignmentApi.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationRoleAssignmentApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -31,7 +31,10 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
                     var dto = new ApplicationAssignmentDto
                         {
                             Id = assignment.Id,
-                            Role = assignment.ResourceDisplayName, ApplicationId = assignment.ResourceId, UserId = assignment.PrincipalId, User = assignment.PrincipalDisplayName
+                            RoleId = assignment.AppRoleId,
+                            ApplicationId = assignment.ResourceId, 
+                            UserId = assignment.PrincipalId, 
+                            User = assignment.PrincipalDisplayName
                         };
                     
                     dto.ApplicationId = assignment.ResourceId;
@@ -62,10 +65,11 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
                     var dto = new ApplicationAssignmentDto
                     {
                         Id = assignment.Id,
-                        Role = assignment.ResourceDisplayName, ApplicationId = assignment.ResourceId, UserId = assignment.PrincipalId, User = assignment.PrincipalDisplayName
+                        RoleId = assignment.AppRoleId, 
+                        ApplicationId = assignment.ResourceId, 
+                        UserId = assignment.PrincipalId, 
+                        User = assignment.PrincipalDisplayName
                     };
-                    
-                    dto.ApplicationId = assignment.ResourceId;
 
                     return dto;
                 }


### PR DESCRIPTION
Role name wasn't available in AppRoleAssignment object. Previously used `assignment.ResourceDisplayName` contained the application name.