### PR TITLE
UserApi supports Azure AD extension properties

### DIFF
--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationApi.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -31,21 +31,20 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
             }
         }
         
-        public async Task<ActionResult<ApplicationDto>> GetApplicationDetails(string applicationId)
+        public async Task<ActionResult<ApplicationDetailsDto>> GetApplicationDetails(string applicationId)
         {
             try
             {
                 var service = new ApplicationService(Configuration);
-                var apps = await service.GetApplications();
+                
+                var app = await service.GetApplicationDetails(applicationId);
 
-                var result = apps.FirstOrDefault(x => string.Equals(x.Id.ToString(), applicationId, StringComparison.InvariantCultureIgnoreCase) || string.Equals(x.AppId.ToString(), applicationId, StringComparison.InvariantCultureIgnoreCase));
-
-                if (result == null)
+                if (app == null)
                 {
                     throw new ServiceException(new Error() { Message = "Application not found" }, null, HttpStatusCode.NotFound);
                 }
                 
-                return result;
+                return app;
             }
             catch (ServiceException e)
             {

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationDetailsDto.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationDetailsDto.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
+{
+    public class ApplicationDetailsDto : ApplicationDto
+    {
+        public List<ExtensionPropertyDto> ExtensionProperties { get; set; }
+    }
+}

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationDto.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationDto.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
@@ -10,6 +10,5 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
         public Guid AppId { get; set; }
         public string Description { get; set; }
         public List<ApplicationRoleDto> ApplicationRoles { get; set; }
-
     }
 }

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationRoleAssignmentApi.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ApplicationRoleAssignmentApi.cs
@@ -89,8 +89,8 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
         {
             try
             {
-                var userService = new UserService();
-                var userDetails = await userService.GetUser(user, Configuration);
+                var userService = new UserService(Configuration);
+                var userDetails = await userService.GetUser(user);
 
                 var appRoleAssignment = new AppRoleAssignment() { ResourceId = Guid.Parse(applicationId), PrincipalId = Guid.Parse(userDetails.Id) };
 

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ExtensionPropertyDto.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Applications/ExtensionPropertyDto.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Weikio.ApiFramework.Plugins.AzureAD.Applications
+{
+    public class ExtensionPropertyDto
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public List<string> TargetObjects { get; set; }
+    }
+}

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Groups/UserGroupApi.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Groups/UserGroupApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -21,8 +21,8 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Groups
         {
             try
             {
-                var userService = new UserService();
-                var userDetails = await userService.GetUser(user, Configuration);
+                var userService = new UserService(Configuration);
+                var userDetails = await userService.GetUser(user);
                 
                 var groupDetails = await GetGroup(group);
 
@@ -45,8 +45,8 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Groups
         {
             try
             {
-                var userService = new UserService();
-                var userDetails = await userService.GetUser(user, Configuration);
+                var userService = new UserService(Configuration);
+                var userDetails = await userService.GetUser(user);
                 
                 var groupDetails = await GetGroup(group);
 

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Users/ExtensionPropertyValue.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Users/ExtensionPropertyValue.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Weikio.ApiFramework.Plugins.AzureAD.Users
+{
+
+    public class ExtensionPropertyValue<T>
+    {
+        public string ObjectType { get; set; }
+
+        public string ObjectId { get; set; }
+
+        public string PropertyName { get; set; }
+
+        public T Value { get; set; }
+
+        public ExtensionPropertyValue<string> ToStringValue()
+        {
+            return new ExtensionPropertyValue<string>()
+            {
+                ObjectType = ObjectType,
+                ObjectId = ObjectId,
+                PropertyName = PropertyName,
+                Value = Value?.ToString()
+            };
+        }
+    }
+}

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Users/UserApi.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Users/UserApi.cs
@@ -24,8 +24,8 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
 
             try
             {
-                var userService = new UserService();
-                var userDetails = await userService.GetUser(user, Configuration);
+                var userService = new UserService(Configuration);
+                var userDetails = await userService.GetUser(user);
 
                 var result = new UserDto(new Guid(userDetails.Id), userDetails.UserPrincipalName, userDetails.Mail, userDetails.DisplayName,
                     userDetails.GivenName,
@@ -62,8 +62,8 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
                     throw new ServiceException(new Error(), null, HttpStatusCode.NotFound);
                 }
 
-                var userService = new UserService();
-                var userDetails = await userService.GetUser(user.Id, Configuration);
+                var userService = new UserService(Configuration);
+                var userDetails = await userService.GetUser(user.Id);
 
                 var result = new UserDto(new Guid(userDetails.Id), userDetails.UserPrincipalName, userDetails.Mail, userDetails.DisplayName,
                     userDetails.GivenName,
@@ -88,7 +88,7 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
 
             try
             {
-                var userService = new UserService();
+                var userService = new UserService(Configuration);
 
                 var changedValues = new User();
 
@@ -107,9 +107,9 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
                     };
                 }
 
-                await userService.UpdateUser(user, changedValues, Configuration);
+                await userService.UpdateUser(user, changedValues);
 
-                var updatedUser = await userService.GetUser(user, Configuration);
+                var updatedUser = await userService.GetUser(user);
 
                 var result = new UserDto(new Guid(updatedUser.Id), updatedUser.UserPrincipalName, updatedUser.Mail, updatedUser.DisplayName,
                         updatedUser.GivenName,
@@ -151,6 +151,52 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
                 result.Email = invitationResult.InvitedUser.Mail;
 
                 return result;
+            }
+            catch (ServiceException e)
+            {
+                var contentResult = new ContentResult { Content = e.Error?.Message, StatusCode = (int)e.StatusCode };
+
+                return contentResult;
+            }
+        }
+
+        public async Task<ActionResult<ExtensionPropertyValue<string>>> SetExtensionPropertyString(string user, string propertyName, string value)
+        {
+            if (string.IsNullOrWhiteSpace(user) || string.IsNullOrWhiteSpace(propertyName))
+            {
+                return new BadRequestResult();
+            }
+
+            try
+            {
+                var userService = new UserService(Configuration);
+
+                var propertyValue = await userService.SetExtensionPropertyValue(user, propertyName, value);
+
+                return propertyValue.ToStringValue();
+            }
+            catch (ServiceException e)
+            {
+                var contentResult = new ContentResult { Content = e.Error?.Message, StatusCode = (int)e.StatusCode };
+
+                return contentResult;
+            }
+        }
+
+        public async Task<ActionResult<ExtensionPropertyValue<string>>> GetExtensionPropertyString(string user, string propertyName)
+        {
+            if (string.IsNullOrWhiteSpace(user) || string.IsNullOrWhiteSpace(propertyName))
+            {
+                return new BadRequestResult();
+            }
+
+            try
+            {
+                var userService = new UserService(Configuration);
+
+                var propertyValue = await userService.GetExtensionPropertyValue(user, propertyName);
+
+                return propertyValue.ToStringValue();
             }
             catch (ServiceException e)
             {

--- a/src/Weikio.ApiFramework.Plugins.AzureAD/Users/UserService.cs
+++ b/src/Weikio.ApiFramework.Plugins.AzureAD/Users/UserService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Graph;
 
@@ -6,9 +7,16 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
 {
     public class UserService
     {
-        public async Task<User> GetUser(string user, AzureAdOptions options)
+        private readonly AzureAdOptions _options;
+
+        public UserService(AzureAdOptions options)
         {
-            var graphServiceClient = await GraphServiceClientFactory.GetGraphClient(options);
+            _options = options;
+        }
+
+        public async Task<User> GetUser(string user)
+        {
+            var graphServiceClient = await GraphServiceClientFactory.GetGraphClient(_options);
 
             // This can automatically retrieve user by Id (guid) or by user principal name (mm.aa@test.com. email must be urlencoded by the requester).
             // The default field set doesn't include department so fields must be listed explicitly.
@@ -20,11 +28,45 @@ namespace Weikio.ApiFramework.Plugins.AzureAD.Users
             return result;
         }
 
-        public async Task UpdateUser(string user, User changedValues, AzureAdOptions options)
+        public async Task UpdateUser(string user, User changedValues)
         {
-            var graphServiceClient = await GraphServiceClientFactory.GetGraphClient(options);
+            var graphServiceClient = await GraphServiceClientFactory.GetGraphClient(_options);
 
             await graphServiceClient.Users[user].Request().UpdateAsync(changedValues);
+        }
+
+        public async Task<ExtensionPropertyValue<object>> GetExtensionPropertyValue(string user, string propertyName)
+        {
+            var graphServiceClient = await GraphServiceClientFactory.GetGraphClient(_options);
+
+            var result = await graphServiceClient.Users[user]
+                .Request()
+                .Select($"id,{propertyName}")
+                .GetAsync();
+
+            result.AdditionalData.TryGetValue(propertyName, out var value);
+
+            return new ExtensionPropertyValue<object>()
+            { 
+                ObjectType = "User",
+                ObjectId = result.Id,
+                PropertyName = propertyName,
+                Value = value
+            };
+        }
+
+        public async Task<ExtensionPropertyValue<object>> SetExtensionPropertyValue(string user, string propertyName, object value)
+        {
+            var changedValues = new User();
+
+            changedValues.AdditionalData = new Dictionary<string, object>()
+            {
+                { propertyName, value }
+            };
+
+            await UpdateUser(user, changedValues);
+
+            return await GetExtensionPropertyValue(user, propertyName);
         }
     }
 }


### PR DESCRIPTION
User extension properties can be fetched and set through UserApi. Currently, only string properties are supported.